### PR TITLE
Fix custom headers override in useHttp

### DIFF
--- a/crm/composables/useHttp.ts
+++ b/crm/composables/useHttp.ts
@@ -9,15 +9,13 @@ export function useHttp<T = any>(
   let baseURL = useRuntimeConfig().public.baseUrl
   const token = getCurrentToken().value
 
-  if (token) {
-    options.headers = { Authorization: `Bearer ${token}` }
-    if (!path.startsWith('pub/')) {
-      baseURL += `${token.split('|')[0]}/`
-    }
+  if (token && !path.startsWith('pub/')) {
+    baseURL += `${token.split('|')[0]}/`
   }
 
   const headers: any = {
     Accept: 'application/json',
+    ...(options.headers as any),
   }
 
   if (token) {

--- a/mob/assets/scss/_dialog.scss
+++ b/mob/assets/scss/_dialog.scss
@@ -235,7 +235,6 @@
   th:first-child {
     padding-left: 26px;
   }
-
 }
 
 .dialog-fullwidth {

--- a/mob/composables/useHttp.ts
+++ b/mob/composables/useHttp.ts
@@ -8,15 +8,13 @@ export const useHttp: useFetchType = (path: string, options = {}) => {
   let baseURL = useRuntimeConfig().public.baseUrl
   const token = getCurrentToken().value
 
-  if (token) {
-    options.headers = { Authorization: `Bearer ${token}` }
-    if (!path.startsWith('pub/')) {
-      baseURL += `${token.split('|')[0]}/`
-    }
+  if (token && !path.startsWith('pub/')) {
+    baseURL += `${token.split('|')[0]}/`
   }
 
   const headers: any = {
     Accept: 'application/json',
+    ...(options.headers as any),
   }
 
   if (token) {


### PR DESCRIPTION
## Summary
- keep user provided headers when calling `useHttp`
- tidy newline formatting in `_dialog.scss`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f7e0eed84832b916368f25f8ca543