### PR TITLE
Add exam scores on /web-reviews

### DIFF
--- a/crm/components/WebReview/List.vue
+++ b/crm/components/WebReview/List.vue
@@ -47,6 +47,19 @@ defineEmits<{
         {{ item.signature }}
       </div>
 
+      <div
+        style="width: 220px; flex: initial !important"
+        class="d-flex flex-column"
+      >
+        <span
+          v-for="es in item.exam_scores"
+          :key="es.id"
+          :class="{ 'text-gray': !es.is_published }"
+        >
+          {{ ExamLabel[es.exam] }}: {{ es.score }}
+        </span>
+      </div>
+
       <div style="width: 60px" class="d-flex align-center ga-2">
         <v-icon :icon="mdiWeb" :class="item.is_published ? 'text-secondary' : 'opacity-2 text-gray'" />
         <v-icon :icon="mdiAccountCircleOutline" :class="item.has_photo ? 'text-secondary' : 'opacity-2 text-gray'" />

--- a/crm/components/WebReview/index.ts
+++ b/crm/components/WebReview/index.ts
@@ -5,6 +5,7 @@ export interface WebReviewResource {
     id: number
     exam: Exam
     score: number
+    is_published: boolean
   }>
   text: string
   signature: string


### PR DESCRIPTION
## Summary
- show exam scores for each review
- include publication status in `WebReviewResource` interface

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm run type-check` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68400b68891c832b872725af93ab3c6d