### PR TITLE
feat: flag schedule draft issues in list

### DIFF
--- a/back/app/Http/Resources/SavedScheduleDraftResource.php
+++ b/back/app/Http/Resources/SavedScheduleDraftResource.php
@@ -13,7 +13,7 @@ class SavedScheduleDraftResource extends JsonResource
     {
         return extract_fields($this, [
             'created_at', 'contract_id', 'year', 'changes',
-            'contract_id', 'is_archived',
+            'contract_id', 'is_archived', 'has_problems_in_list',
         ], [
             'client' => new PersonResource($this->client),
             'user' => new PersonResource($this->user),

--- a/crm/components/ScheduleDraft/List.vue
+++ b/crm/components/ScheduleDraft/List.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SavedScheduleDraftResource } from '.'
+import { mdiAlertBox } from '@mdi/js'
 
 const { items } = defineProps<{ items: SavedScheduleDraftResource[] }>()
 const emit = defineEmits<{
@@ -42,6 +43,12 @@ const router = useRouter()
             inline
             :content="item.changes"
           ></v-badge>
+          <v-icon
+            v-if="item.has_problems_in_list"
+            :icon="mdiAlertBox"
+            color="error"
+            class="ml-1"
+          />
         </td>
 
         <td width="300" class="text-gray">

--- a/crm/components/ScheduleDraft/index.ts
+++ b/crm/components/ScheduleDraft/index.ts
@@ -12,6 +12,7 @@ export interface SavedScheduleDraftResource {
   is_archived: boolean
   changes: number
   contract_id: number | null
+  has_problems_in_list: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- detect problematic group assignments in ScheduleDraft model
- expose `has_problems_in_list` in saved draft resource
- show alert icon for drafts with problematic changes

## Testing
- `php -l back/app/Models/ScheduleDraft.php`
- `php -l back/app/Http/Resources/SavedScheduleDraftResource.php`
- `npm run lint` *(fails: Cannot read properties of null (reading 'childScopes'))*
- `npm run type-check` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e1aa6b24832bb76608e3225c4b53